### PR TITLE
Actually return promised °C instead of wrongly calculated °F

### DIFF
--- a/DS18B20/DS18B20.ino
+++ b/DS18B20/DS18B20.ino
@@ -79,5 +79,7 @@ float getTemp(){
   float tempRead = ((MSB << 8) | LSB); //using two's compliment
   float TemperatureSum = tempRead / 16;
 
-  return (TemperatureSum * 18 + 5)/10 + 32;
+  return (TemperatureSum); // For really returning °C
+  // return (TemperatureSum * 1.8 + 32); // Use this return to correctly return °F
+  // https://www.rapidtables.com/convert/temperature/how-celsius-to-fahrenheit.html
 }


### PR DESCRIPTION
As it says in the comment of function getTemp, the function is supposed to return °C.
In the original code however, a sortof°Fahrenheit - value is retured (the conversion-formula is wrong).
Please use this code to actually return °C.