### PR TITLE
Add more accurate distance calculation constants for Sharp GP2Y0A21YK IR Sensor

### DIFF
--- a/sharp/sharp.ino
+++ b/sharp/sharp.ino
@@ -20,11 +20,11 @@ void loop(void) {
 
   int reading = analogRead(A5);
 
-  int calculated = (6762/(reading-9))-4;
+  float calculated = (6000/(float)(reading-9))-3.2;
 
   Serial.println(calculated);
 
-  sprintf(cmstring, "%3d", calculated);
+  sprintf(cmstring, "%.3f", calculated);
   display.write("distance: ");
   display.write(cmstring);
   display.write("cm");


### PR DESCRIPTION
These changes make the distance calculation for the Sharp GP2Y0A21YK IR Sensor more accurate, particularly in the 30-80cm range. 

I extracted the points shown in the chart for distance vs voltage in the GP2Y0A21YK datasheet with WebPlotDigitizer and plotted them in desmos. This showed that the current formula for computing distance isn't very good, so I adjusted the constants for a better fit and tried them out on my sensor. You can see the plots here:  https://www.desmos.com/calculator/fivql4vfdm

Here are the results I collected, using a dollar bill for measuring out lengths and comparing measured results for a piece of white paper at the given distance: 
| Actual Value | Value Measured with Old Constants | Value Measured with New Constants |
| --- | --- | --- |
| 15.5956 | 15.1 | 14.14 | 
| 31.1912 | 36.23 | 32.03 |
| 46.7868 | 56.92 | 48.52 | 
| 62.3824 | 76.5 | 64.22 | 
| 77.978 | 95.44 | 83.76 | 
| 93.5736 | 108.7 | 96.8 |

So it seems like these improvements manifest in real-world results with the sensor.